### PR TITLE
Add support for arm64 and clang 16

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -1,6 +1,5 @@
 -d:noUndefinedBitOpts
 -d:nimNoGetRandom
---passC:"-mpopcnt"
 --passC:"-static -no-pie"
 path = "$projectPath/src"
 #-d:useLibzipSrc
@@ -8,3 +7,11 @@ path = "$projectPath/src"
 #--passL:"-fuse-ld=gold"
 #--passC:"-fsanitize=address"
 #--passC:"-fno-omit-frame-pointer"
+
+@if amd64:
+  --passC:"-mpopcnt"
+@end
+
+@if clang:
+  --passC:"-Wno-incompatible-function-pointer-types"
+@end


### PR DESCRIPTION
Hi, this PR adds support for arm64 and Clang 16.

Compilation currently fails on arm64 (on Mac) with:

```text
clang: error: unsupported option '-mpopcnt' for target 'arm64-apple-darwin24.5.0'
```

and Clang 16+ with:

```text
... /Users/user/.cache/nim/slivar_d/@mslivarpkg@sevaluator.nim.c:3980:67: error: incompatible function pointer types passing 'tyProc__o3F5tYsDphYxfqMdvjrdTQ' (aka 'void (*)(void *, char *)') to parameter of type 'duk_fatal_function' (aka 'void (*)(void *, const char *)') [-Wincompatible-function-pointer-types]
...  3980 |         (*T2_).ctx = duk_create_heap(NIM_NIL, NIM_NIL, NIM_NIL, NIM_NIL, my_fatal_1);
...       |                                                                          ^~~~~~~~~~
... /Users/user/.nimble/pkgs2/duktape-0.1.0-b842ad7af51f53817e48ecd23e31cf35c46c5cfc/duktape/src/duktape.h:482:49: note: passing argument to parameter 'fatal_handler' here
...   482 |                              duk_fatal_function fatal_handler);
...       |                                                 ^
... /Users/user/.cache/nim/slivar_d/@mslivarpkg@sevaluator.nim.c:4560:45: error: incompatible function pointer types passing 'tyProc__9bXxZjCGS3SX1SUzfb9cT9cag' (aka 'int (*)(void *)') to parameter of type 'duk_c_function' (aka 'int (*)(struct duk_hthread *)') [-Wincompatible-function-pointer-types]
...  4560 |         T170_ = duk_push_c_function((*result).ctx, debug__slivarpkgZevaluator_u845, ((int)-1));
...       |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... /Users/user/.nimble/pkgs2/duktape-0.1.0-b842ad7af51f53817e48ecd23e31cf35c46c5cfc/duktape/src/duktape.h:706:82: note: passing argument to parameter 'func' here
...   706 | DUK_EXTERNAL_DECL duk_idx_t duk_push_c_function(duk_context *ctx, duk_c_function func, duk_idx_t nargs);
...       |                                                                                  ^
... 2 errors generated.
```