### PR TITLE
Improve version message when compiled from release archive

### DIFF
--- a/src/slivarpkg/version.nim
+++ b/src/slivarpkg/version.nim
@@ -1,2 +1,4 @@
+import strutils
+
 const slivarVersion* = "0.3.4"
-const slivarGitCommit* = staticExec("git rev-parse --verify HEAD")
+const slivarGitCommit* = staticExec("git rev-parse --verify HEAD 2>/dev/null").strip()


### PR DESCRIPTION
When slivar is compiled from a release archive rather than Git, the version is printed as:

```text
> slivar version: 0.3.4 fatal: not a git repository (or any of the parent directories): .git
```

This commit changes it to an empty string, but it only works on Linux and Mac.